### PR TITLE
Update Chat.php

### DIFF
--- a/src/DTO/Chat.php
+++ b/src/DTO/Chat.php
@@ -14,7 +14,7 @@ class Chat implements Arrayable
     public const TYPE_SUPERGROUP = 'supergroup';
     public const TYPE_CHANNEL = 'channel';
 
-    private int $id;
+    private string $id;
     private string $type;
     private string $title;
 
@@ -23,7 +23,7 @@ class Chat implements Arrayable
     }
 
     /**
-     * @param array{id:int, type:string, title?:string} $data
+     * @param array{id:string, type:string, title?:string} $data
      */
     public static function fromArray(array $data): Chat
     {
@@ -36,7 +36,7 @@ class Chat implements Arrayable
         return $chat;
     }
 
-    public function id(): int
+    public function id(): string
     {
         return $this->id;
     }


### PR DESCRIPTION
An integer data type is a non-decimal number between **-2147483648** and **2147483647** in 32 bit systems.
Currently, Telegram assigns _chat_ids_ greater than 2147483647 for new accounts, so they cannot be treated as `int` data by PHP without being distorted in 32 bit systems. Using the `string` type instead of `int` to manipulate the _chat_id_ could circumvent this limitation.